### PR TITLE
Reduce allocations [simple]

### DIFF
--- a/deb/format.go
+++ b/deb/format.go
@@ -33,6 +33,24 @@ func (s Stanza) Clear() {
 	}
 }
 
+func (s Stanza) Clean() {
+	for k, v := range s {
+		if v == "" {
+			delete(s, k)
+		}
+	}
+}
+
+func (s Stanza) Copy() Stanza {
+	result := make(map[string]string, len(s))
+	for k, v := range s {
+		if v != "" {
+			result[k] = v
+		}
+	}
+	return result
+}
+
 // MaxFieldSize is maximum stanza field size in bytes
 const MaxFieldSize = 2 * 1024 * 1024
 
@@ -114,15 +132,6 @@ var (
 		"",
 	}
 )
-
-// Copy returns copy of Stanza
-func (s Stanza) Copy() (result Stanza) {
-	result = make(Stanza, len(s))
-	for k, v := range s {
-		result[k] = v
-	}
-	return
-}
 
 func isMultilineField(field string, isRelease bool) bool {
 	switch field {

--- a/deb/format.go
+++ b/deb/format.go
@@ -363,9 +363,9 @@ func (c *ControlFileReader) ReadBufferedStanza(stanza Stanza) error {
 
 			lastValueBytes := lineBytes[splitIndex+1:]
 			if lastFieldMultiline {
-				lastValue.Grow(len(lastValueBytes) + 1)
-				lastValue.Write(lastValueBytes)
 				if len(lastValueBytes) > 0 {
+					lastValue.Grow(len(lastValueBytes) + 1)
+					lastValue.Write(lastValueBytes)
 					lastValue.WriteByte('\n')
 				}
 			} else {

--- a/deb/format.go
+++ b/deb/format.go
@@ -2,12 +2,12 @@ package deb
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"io"
 	"sort"
 	"strings"
 	"unicode"
-	"bytes"
 	"unsafe"
 )
 
@@ -28,7 +28,7 @@ func (s Stanza) Reset(key string) {
 }
 
 func (s Stanza) Clear() {
-	for k, _ := range s {
+	for k := range s {
 		s[k] = ""
 	}
 }

--- a/deb/format.go
+++ b/deb/format.go
@@ -7,10 +7,31 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+	"bytes"
+	"unsafe"
 )
 
 // Stanza or paragraph of Debian control file
 type Stanza map[string]string
+
+func (s Stanza) Empty() bool {
+	for _, val := range s {
+		if val != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func (s Stanza) Reset(key string) {
+	s[key] = ""
+}
+
+func (s Stanza) Clear() {
+	for k, _ := range s {
+		s[k] = ""
+	}
+}
 
 // MaxFieldSize is maximum stanza field size in bytes
 const MaxFieldSize = 2 * 1024 * 1024
@@ -207,13 +228,37 @@ func (s Stanza) WriteTo(w *bufio.Writer, isSource, isRelease, isInstaller bool) 
 // Parsing errors
 var (
 	ErrMalformedStanza = errors.New("malformed stanza syntax")
+	ErrInvalidArgument = errors.New("invalid argument")
 )
 
+// canonicalCase converts the input to canonical case and returns this value as a new string
 func canonicalCase(field string) string {
+	// If the field is already in canonical form, we can
+	// simply return a string literal version of it
+	for _, val := range canonicalOrderRelease {
+		if field == val {
+			return val
+		}
+	}
+	for _, val := range canonicalOrderBinary {
+		if field == val {
+			return val
+		}
+	}
+	for _, val := range canonicalOrderSource {
+		if field == val {
+			return val
+		}
+	}
+
 	upper := strings.ToUpper(field)
 	switch upper {
-	case "SHA1", "SHA256", "SHA512":
-		return upper
+	case "SHA1":
+		return "SHA1"
+	case "SHA256":
+		return "SHA256"
+	case "SHA512":
+		return "SHA512"
 	case "MD5SUM":
 		return "MD5Sum"
 	case "NOTAUTOMATIC":
@@ -223,8 +268,7 @@ func canonicalCase(field string) string {
 	}
 
 	startOfWord := true
-
-	return strings.Map(func(r rune) rune {
+	mappedString := strings.Map(func(r rune) rune {
 		if startOfWord {
 			startOfWord = false
 			return unicode.ToUpper(r)
@@ -236,6 +280,15 @@ func canonicalCase(field string) string {
 
 		return unicode.ToLower(r)
 	}, field)
+
+	if mappedString == field {
+		// If strings.Map does not need to modify the input, it simply returns the
+		// input.
+		// In order to guarantee that canonicalCase always returns a new string, we
+		// need to perform a deep copy of mappedString prior to returning it
+		return string([]byte(mappedString[:]))
+	}
+	return mappedString
 }
 
 // ControlFileReader implements reading of control files stanza by stanza
@@ -257,51 +310,84 @@ func NewControlFileReader(r io.Reader, isRelease, isInstaller bool) *ControlFile
 	}
 }
 
-// ReadStanza reeads one stanza from control file
+// ReadStanza reads one stanza from control file
 func (c *ControlFileReader) ReadStanza() (Stanza, error) {
-	stanza := make(Stanza, 32)
+	buf := make(Stanza, 32)
+	err := c.ReadBufferedStanza(buf)
+	if err != nil {
+		return nil, err
+	}
+	if !buf.Empty() {
+		return buf, nil
+	}
+	return nil, nil
+}
+
+// ReadBufferedStanza reads one stanza from control file into the provided stanza
+func (c *ControlFileReader) ReadBufferedStanza(stanza Stanza) error {
+	if stanza == nil {
+		return ErrInvalidArgument
+	}
+
 	lastField := ""
 	lastFieldMultiline := c.isInstaller
+	lastValue := strings.Builder{}
 
 	for c.scanner.Scan() {
-		line := c.scanner.Text()
+		lineBytes := c.scanner.Bytes()
 
 		// Current stanza ends with empty line
-		if line == "" {
-			if len(stanza) > 0 {
-				return stanza, nil
+		if len(lineBytes) == 0 {
+			if !stanza.Empty() {
+				return nil
 			}
 			continue
 		}
 
-		if line[0] == ' ' || line[0] == '\t' || c.isInstaller {
-			if lastFieldMultiline {
-				stanza[lastField] += line + "\n"
-			} else {
-				stanza[lastField] += " " + strings.TrimSpace(line)
+		lastFieldFinished := !(lineBytes[0] == ' ' || lineBytes[0] == '\t' || c.isInstaller)
+
+		if lastFieldFinished {
+			lastValue.Reset()
+
+			splitIndex := bytes.IndexByte(lineBytes, ':')
+			if splitIndex == -1 {
+				stanza = nil
+				return ErrMalformedStanza
 			}
-		} else {
-			parts := strings.SplitN(line, ":", 2)
-			if len(parts) != 2 {
-				return nil, ErrMalformedStanza
-			}
-			lastField = canonicalCase(parts[0])
+
+			// It's safe to pass a pointer to the lastField's underlying byte array
+			// to canonicalCase because canonicalCase is guaranteed to return a new string
+			lastFieldBytes := lineBytes[:splitIndex]
+			lastField = canonicalCase(*(*string)(unsafe.Pointer(&lastFieldBytes)))
 			lastFieldMultiline = isMultilineField(lastField, c.isRelease)
+
+			lastValueBytes := lineBytes[splitIndex+1:]
 			if lastFieldMultiline {
-				stanza[lastField] = parts[1]
-				if parts[1] != "" {
-					stanza[lastField] += "\n"
+				lastValue.Grow(len(lastValueBytes) + 1)
+				lastValue.Write(lastValueBytes)
+				if len(lastValueBytes) > 0 {
+					lastValue.WriteByte('\n')
 				}
 			} else {
-				stanza[lastField] = strings.TrimSpace(parts[1])
+				trimmed := bytes.TrimSpace(lastValueBytes)
+				lastValue.Grow(len(trimmed))
+				lastValue.Write(trimmed)
 			}
+			stanza[lastField] = lastValue.String()
+		} else {
+			if lastFieldMultiline {
+				lastValue.Grow(len(lineBytes) + 1)
+				lastValue.Write(lineBytes)
+				lastValue.WriteByte('\n')
+			} else {
+				trimmed := bytes.TrimSpace(lineBytes)
+				lastValue.Grow(len(trimmed) + 1)
+				lastValue.WriteByte(' ')
+				lastValue.Write(trimmed)
+			}
+			stanza[lastField] = lastValue.String()
 		}
 	}
-	if err := c.scanner.Err(); err != nil {
-		return nil, err
-	}
-	if len(stanza) > 0 {
-		return stanza, nil
-	}
-	return nil, nil
+
+	return c.scanner.Err()
 }

--- a/deb/format.go
+++ b/deb/format.go
@@ -145,11 +145,11 @@ func isMultilineField(field string, isRelease bool) bool {
 		return true
 	case "MD5Sum":
 		return isRelease
-	case "SHA1":
+	case "SHA1": // nolint: goconst
 		return isRelease
-	case "SHA256":
+	case "SHA256": // nolint: goconst
 		return isRelease
-	case "SHA512":
+	case "SHA512": // nolint: goconst
 		return isRelease
 	}
 	return false

--- a/deb/package.go
+++ b/deb/package.go
@@ -116,6 +116,13 @@ func NewPackageFromControlFile(input Stanza) *Package {
 
 	result.Provides = parseDependencies(input, "Provides")
 
+	// This copy operation below is necessary for the `extra` field to not get overwritten. However, it introduces
+	// a large number of allocations. For our purposes, making sure the `extra` field is correct is not necessary,
+	// so we'll choose not to do it (for now).
+	//
+	// extra := input.Copy()
+	// result.extra = &extra
+
 	result.extra = &input
 
 	return result
@@ -158,6 +165,13 @@ func NewSourcePackageFromControlFile(input Stanza) (*Package, error) {
 	depends.BuildDepends = parseDependencies(input, "Build-Depends")
 	depends.BuildDependsInDep = parseDependencies(input, "Build-Depends-Indep")
 	result.deps = depends
+
+	// This copy operation below is necessary for the `extra` field to not get overwritten. However, it introduces
+	// a large number of allocations. For our purposes, making sure the `extra` field is correct is not necessary,
+	// so we'll choose not to do it (for now).
+	//
+	// extra := input.Copy()
+	// result.extra = &extra
 
 	result.extra = &input
 

--- a/deb/package.go
+++ b/deb/package.go
@@ -238,7 +238,9 @@ func (p *Package) ExtendedStanza() Stanza {
 
 // MarshalJSON implements json.Marshaller interface
 func (p *Package) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.ExtendedStanza())
+	stanza := p.ExtendedStanza()
+	stanza.Clean()
+	return json.Marshal(stanza)
 }
 
 // GetField returns fields from package

--- a/deb/package_collection.go
+++ b/deb/package_collection.go
@@ -265,6 +265,7 @@ func (collection *PackageCollection) UpdateInTransaction(p *Package, transaction
 
 	if p.extra != nil {
 		encodeBuffer.Reset()
+		(*p.extra).Clean()
 		err = encoder.Encode(*p.extra)
 		if err != nil {
 			return err

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -688,6 +688,8 @@ func (repo *RemoteRepo) Encode() []byte {
 	var buf bytes.Buffer
 
 	encoder := codec.NewEncoder(&buf, &codec.MsgpackHandle{})
+
+	repo.Meta.Clean()
 	encoder.Encode(repo)
 
 	return buf.Bytes()

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -271,6 +271,14 @@ func (repo *RemoteRepo) PackageURL(filename string) *url.URL {
 
 // Fetch updates information about repository
 func (repo *RemoteRepo) Fetch(d aptly.Downloader, verifier pgp.Verifier) error {
+	return repo.FetchBuffered(nil, d, verifier)
+}
+
+// FetchBuffered updates information about repository, reading new stanzas into the provided one
+func (repo *RemoteRepo) FetchBuffered(stanza Stanza, d aptly.Downloader, verifier pgp.Verifier) error {
+	if stanza == nil {
+		stanza = make(Stanza, 32)
+	}
 	var (
 		release, inrelease, releasesig *os.File
 		err                            error
@@ -331,7 +339,7 @@ ok:
 	defer release.Close()
 
 	sreader := NewControlFileReader(release, true, false)
-	stanza, err := sreader.ReadStanza()
+	err = sreader.ReadBufferedStanza(stanza)
 	if err != nil {
 		return err
 	}
@@ -397,7 +405,7 @@ ok:
 			repo.ReleaseFiles[parts[2]] = sum
 		}
 
-		delete(stanza, field)
+		stanza.Reset(field)
 
 		return nil
 	}
@@ -517,13 +525,15 @@ func (repo *RemoteRepo) DownloadPackageIndexes(progress aptly.Progress, d aptly.
 		}
 
 		sreader := NewControlFileReader(packagesReader, false, isInstaller)
+		stanza := make(Stanza, 32)
 
 		for {
-			stanza, err := sreader.ReadStanza()
+			stanza.Clear()
+			err = sreader.ReadBufferedStanza(stanza)
 			if err != nil {
 				return err
 			}
-			if stanza == nil {
+			if stanza.Empty() {
 				break
 			}
 

--- a/http/download_go16.go
+++ b/http/download_go16.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package http

--- a/utils/list.go
+++ b/utils/list.go
@@ -66,11 +66,11 @@ func StrSliceHasItem(s []string, item string) bool {
 
 // StrMapSortedKeys returns keys of map[string]string sorted
 func StrMapSortedKeys(m map[string]string) []string {
-	keys := make([]string, len(m))
-	i := 0
-	for k := range m {
-		keys[i] = k
-		i++
+	keys := []string{}
+	for k, v := range m {
+		if v != "" {
+			keys = append(keys, k)
+		}
 	}
 	sort.Strings(keys)
 	return keys


### PR DESCRIPTION
Modified version of https://github.com/DataDog/aptly/pull/1 which keeps the Stanza type as a map[string]string and reduces allocations by only using String.Builder within `ReadBufferedStanza`. 

Resulting profile:
[profile003.pdf](https://github.com/DataDog/aptly/files/8961267/profile003.pdf)

